### PR TITLE
Hide PHP errors from displaying on webpage

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,4 +1,6 @@
 <?php
+ini_set('display_errors', '0');
+
 define('MIN_PERCENTAGE', 5);
 define('MAX_PERCENTAGE', 95);
 define('DEFAULT_PERCENTAGE', 7);


### PR DESCRIPTION
Added `ini_set('display_errors', '0')` to config.php to prevent PHP errors from displaying on the webpage and causing formatting issues.

Fixes #21

Generated with [Claude Code](https://claude.ai/code)