### PR TITLE
Implement automatic cash-out when max rewards reached

### DIFF
--- a/add.php
+++ b/add.php
@@ -10,11 +10,15 @@
   <body>
     <?php
       $kid = $_GET["kid"];
+      $cashout = isset($_GET["cashout"]) ? $_GET["cashout"] : false;
       $data = json_decode(file_get_contents('kids.json'));
-      if ($data->$kid->rewards == $data->$kid->maxRewards) {
+
+      if ($cashout && $data->$kid->rewards == $data->$kid->maxRewards) {
+        // Cash out and reset
         $data->$kid->cash = $data->$kid->cash + $data->$kid->pay;
         $data->$kid->rewards = 0;
       } else {
+        // Increment reward
         $data->$kid->rewards = $data->$kid->rewards + 1;
       }
       $newData = json_encode($data, JSON_PRETTY_PRINT);

--- a/index.php
+++ b/index.php
@@ -12,7 +12,21 @@ $k2p = calculatePercentage($data->k2->rewards, $data->k2->maxRewards);
 <head>
   <title>Kids Reward System</title>
   <link rel="stylesheet" type="text/css" href="./styles.php">
-  <meta http-equiv="refresh" content="300" />
+  <?php
+    // Check if any kid has reached max rewards and should auto-cashout
+    $autoCashout = '';
+    if ($data->k1->rewards == $data->k1->maxRewards && $data->k1->maxRewards > 0) {
+      $autoCashout = 'add.php?kid=k1&cashout=1';
+    } elseif (isset($data->k2) && $data->k2->rewards == $data->k2->maxRewards && $data->k2->maxRewards > 0) {
+      $autoCashout = 'add.php?kid=k2&cashout=1';
+    }
+
+    if ($autoCashout) {
+      echo '<meta http-equiv="refresh" content="1;url=' . $autoCashout . '" />';
+    } else {
+      echo '<meta http-equiv="refresh" content="300" />';
+    }
+  ?>
   <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
   <meta http-equiv="Pragma" content="no-cache" />
   <meta http-equiv="Expires" content="0" />


### PR DESCRIPTION
## Summary
- Modified add.php to accept cashout parameter for automatic cash-out
- Modified index.php to auto-redirect when max rewards reached
- Max rewards now display for 1 second before auto-cashing out
- No additional click required after reaching max rewards

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)